### PR TITLE
Version/0.1.9

### DIFF
--- a/admin_interface/static/admin/css/nav_sidebar.css
+++ b/admin_interface/static/admin/css/nav_sidebar.css
@@ -171,8 +171,6 @@
   /*transition: left .3s;*/
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-  color: white;
-  background-color:#205493;
 }
 #open-nav-sidebar-button.hidden {
   display:none;

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -38,9 +38,10 @@
 {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
 {% if errors %}
   {% get_508_compliant_error_message %}
-    <p class="errornote">
+    <p class="errornote" focus tabindex="-1">
       {% translate error_message %}
     </p>
+    <script src="{% static 'admin_interface/508/required-field-error.js' %}" defer></script>
     {{ adminform.form.non_field_errors }}
 {% endif %}
 
@@ -64,7 +65,6 @@
 
 
 {% block admin_change_form_document_ready %}
-    <script src="{% static 'admin_interface/508/required-field-error.js' %}" defer></script>
     <script id="django-admin-form-add-constants"
             src="{% static 'admin/js/change_form.js' %}"
             {% if adminform and add %}

--- a/admin_interface/templates/admin/nav_sidebar.html
+++ b/admin_interface/templates/admin/nav_sidebar.html
@@ -1,12 +1,10 @@
 {% load i18n %}
 
 
-<!-- <div id="shadow-box-main"></div> -->
-
-<input value="Menu" type="button" class="sticky closed-button" id="open-nav-sidebar-button" aria-label="{% translate 'Toggle navigation' %}"></input>
+<input type="button" class="sticky closed-button" id="open-nav-sidebar-button" aria-label="{% translate 'Toggle navigation' %}" value="Menu">
 <!-- <button class="sticky toggle-nav-sidebar" id="open-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}">Menu</button> -->
 <nav class="sticky open" id="nav-sidebar">
-  <input type="button" class="toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}" value="Close Menu"></button>
+  <input type="button" class="toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}" value="Close Menu">
   <input type="search" id="nav-filter"
          placeholder="{% translate 'Start typing to filter…' %}"
          aria-label="{% translate 'Filter navigation items' %}">


### PR DESCRIPTION
[Give open side menu button focus state.](https://github.com/raft-tech/django-admin-508/commit/f5d91779f2ce655b1e5adff03f6078c8f62684d0)
    @[riatzukiza](https://github.com/raft-tech/django-admin-508/commits?author=riatzukiza)


[set focus for errornote](https://github.com/raft-tech/django-admin-508/commit/342675a9447fd5bd24d909b78241599d02c92672)
@[riatzukiza](https://github.com/raft-tech/django-admin-508/commits?author=riatzukiza)


[fix end tag issues](https://github.com/raft-tech/django-admin-508/commit/2dc9162201d763e4c87480eb0e86759ee2e4304d)
@[riatzukiza](https://github.com/raft-tech/django-admin-508/commits?author=riatzukiza)
